### PR TITLE
Use long opt `--no-data` instead of short opt `-d`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You should test all of the changes before committing them to your database.
 
 The first thing to test is that the SQL generated from the conversion script is correct.  To do this, you can dump the structure of your database:
 
-    server> mysqldump -d -h localhost -u dbuser -p mydatabase > structure.sql
+    server> mysqldump --no-data -h localhost -u dbuser -p mydatabase > structure.sql
 
 And import this structure to another test MySQL database:
 


### PR DESCRIPTION
This is a README document, so must be readily comprehensible by its
likely audience. The `-d` short option is not terribly easy to find in
the `mysqldump` man page due to the large number of options starting
with the string `-d`. Therefore, we invoke it as a long option instead.

The -h, -u, and -p short options are likely to be so familiar to MySQL
users as not to warrant expansion to long options for comprehensibility,
so we leave them untouched.